### PR TITLE
Encode usernames for GitHub stats API requests

### DIFF
--- a/src/api/githubReadmeStats.spec.ts
+++ b/src/api/githubReadmeStats.spec.ts
@@ -29,6 +29,15 @@ describe('githubReadmeStats', () => {
         'https://github-readme-stats.vercel.app/api?username=test_user&count_private=true&show_icons=true&theme=algolia',
       expectedResult: { data: 'test' },
     },
+    {
+      username: 'user name',
+      themeType: ThemeType.LIGHT,
+      expectedUrl:
+        `https://github-readme-stats.vercel.app/api?username=${encodeURIComponent(
+          'user name'
+        )}&count_private=true&show_icons=true`,
+      expectedResult: { data: 'test' },
+    },
   ])(
     'getGitHubStats with username=%s and themeType=%s',
     async ({ username, themeType, expectedUrl, expectedResult }) => {
@@ -52,6 +61,15 @@ describe('githubReadmeStats', () => {
       themeType: ThemeType.DARK,
       expectedUrl:
         'https://github-readme-stats.vercel.app/api/top-langs/?username=test_user&layout=compact&theme=algolia',
+      expectedResult: { data: 'test' },
+    },
+    {
+      username: 'user name',
+      themeType: ThemeType.LIGHT,
+      expectedUrl:
+        `https://github-readme-stats.vercel.app/api/top-langs/?username=${encodeURIComponent(
+          'user name'
+        )}&layout=compact`,
       expectedResult: { data: 'test' },
     },
   ])(

--- a/src/api/githubReadmeStats.ts
+++ b/src/api/githubReadmeStats.ts
@@ -4,10 +4,11 @@ import axios from 'axios';
 const darkthemeParam = 'theme=algolia';
 
 export const getGitHubStats = (username: string, themeType: ThemeType) => {
+  const encodedUsername = encodeURIComponent(username);
   const url =
     themeType === ThemeType.LIGHT
-      ? `https://github-readme-stats.vercel.app/api?username=${username}&count_private=true&show_icons=true`
-      : `https://github-readme-stats.vercel.app/api?username=${username}&count_private=true&show_icons=true&${darkthemeParam}`;
+      ? `https://github-readme-stats.vercel.app/api?username=${encodedUsername}&count_private=true&show_icons=true`
+      : `https://github-readme-stats.vercel.app/api?username=${encodedUsername}&count_private=true&show_icons=true&${darkthemeParam}`;
   return axios.get<string>(url);
 };
 
@@ -15,10 +16,11 @@ export const getGitHubTopLanguage = (
   username: string,
   themeType: ThemeType
 ) => {
+  const encodedUsername = encodeURIComponent(username);
   const url =
     themeType === ThemeType.LIGHT
-      ? `https://github-readme-stats.vercel.app/api/top-langs/?username=${username}&layout=compact`
-      : `https://github-readme-stats.vercel.app/api/top-langs/?username=${username}&layout=compact&${darkthemeParam}`;
+      ? `https://github-readme-stats.vercel.app/api/top-langs/?username=${encodedUsername}&layout=compact`
+      : `https://github-readme-stats.vercel.app/api/top-langs/?username=${encodedUsername}&layout=compact&${darkthemeParam}`;
   return axios.get<string>(url);
 };
 


### PR DESCRIPTION
## Summary
- encode usernames in GitHub stats URL generation
- test username encoding

## Testing
- `yarn build`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68abccd92758832d961769064e2373c7