### PR TITLE
refactor: optimize popup fetching

### DIFF
--- a/src/popup.spec.tsx
+++ b/src/popup.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { Popup } from '@/popup';
+import { getGitHubStats, getGitHubTopLanguage, getGitHubUsername } from '@/api';
+
+jest.mock('@/api', () => ({
+  getGitHubStats: jest.fn().mockResolvedValue({ data: 'stats' }),
+  getGitHubTopLanguage: jest.fn().mockResolvedValue({ data: 'lang' }),
+  getGitHubUsername: jest.fn().mockReturnValue('testuser'),
+}));
+
+describe('Popup', () => {
+  beforeEach(() => {
+    const globalTyped = global as { chrome?: unknown };
+    globalTyped.chrome = {
+      tabs: {
+        query: (
+          _: Record<string, unknown>,
+          cb: (tabs: { url: string }[]) => void
+        ) => cb([{ url: 'https://github.com/testuser' }]),
+      },
+    };
+  });
+
+  it('fetches stats only once', async () => {
+    render(
+      <ChakraProvider>
+        <Popup />
+      </ChakraProvider>
+    );
+    await waitFor(() => {
+      expect(getGitHubStats).toHaveBeenCalledTimes(1);
+    });
+    expect(getGitHubTopLanguage).toHaveBeenCalledTimes(1);
+    expect(getGitHubUsername).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -2,11 +2,11 @@ import { getGitHubStats, getGitHubTopLanguage, getGitHubUsername } from '@/api';
 import { Header, StatsBody, StatsForm } from '@/components';
 import { ThemeType } from '@/types/enums';
 import { Box, ChakraProvider, useColorMode } from '@chakra-ui/react';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useForm } from 'react-hook-form';
 
-const Popup = () => {
+export const Popup = () => {
   const [username, setUsername] = useState('');
   const [currentStats, setCurrentStats] = useState('');
   const [currentTopLanguage, setCurrentTopLanguage] = useState('');
@@ -27,21 +27,23 @@ const Popup = () => {
     });
   }, []);
 
-  useEffect(() => {
-    const fetch = async (username: string) => {
+  const fetchStats = useCallback(
+    async (username: string) => {
       const themeType =
         colorMode === 'light' ? ThemeType.LIGHT : ThemeType.DARK;
       const stats = await getGitHubStats(username, themeType);
       const lang = await getGitHubTopLanguage(username, themeType);
       setCurrentTopLanguage(lang.data);
       setCurrentStats(stats.data);
-    };
-    console.log(username);
+    },
+    [colorMode]
+  );
+
+  useEffect(() => {
     if (username !== '') {
-      console.log(username);
-      fetch(username);
+      fetchStats(username);
     }
-  }, [username, colorMode, currentStats, currentTopLanguage]);
+  }, [username, fetchStats]);
 
   return (
     <>
@@ -62,12 +64,13 @@ const Popup = () => {
 };
 
 const container = document.getElementById('root');
-if (!container) throw new Error('container not found');
-const root = createRoot(container);
-root.render(
-  <React.StrictMode>
-    <ChakraProvider>
-      <Popup />
-    </ChakraProvider>
-  </React.StrictMode>
-);
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <ChakraProvider>
+        <Popup />
+      </ChakraProvider>
+    </React.StrictMode>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor popup fetch effect to depend only on username and color mode
- add tests to ensure GitHub API calls trigger once

## Testing
- `npm test`
- `yarn build`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68abccdfdf74832d8d5beb875aa1cbb3