### PR TITLE
chore: reduce extension permissions

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -7,6 +7,6 @@
     "default_icon": "icon.png",
     "default_popup": "popup.html"
   },
-  "permissions": ["tabs"],
-  "host_permissions": ["https://github-readme-stats.vercel.app/*"]
+  "permissions": ["activeTab"],
+  "host_permissions": ["https://github-readme-stats.vercel.app/api*"]
 }


### PR DESCRIPTION
## Summary
- restrict extension permission from `tabs` to `activeTab`
- limit host access to GitHub Readme Stats API

## Testing
- `npm run lint`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68abcce89dc8832d91da316d56bb39b8