### PR TITLE
fix: harden CI against supply chain attacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
   lint:
     runs-on: ubuntu-latest
     needs: prepare
@@ -46,7 +46,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - name: yarn lint
         run: yarn lint
   test:
@@ -66,7 +66,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - name: yarn test
         run: yarn test
   build:
@@ -86,7 +86,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - name: build
         run: yarn build
       - name: Update manifest.json

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "7 days",
   "assignees": ["tokku5552"],
   "major": {
     "enabled": false


### PR DESCRIPTION
## Summary
- CI の `yarn install` に `--ignore-scripts` を追加し、postinstall フック経由のマルウェア実行を防止
- Renovate に `minimumReleaseAge: 7 days` を追加し、公開後7日未満のパッケージを自動更新対象から除外

## Background
axios 1.14.1 サプライチェーン攻撃（2026-03-30）への対応。攻撃は postinstall フックで RAT を展開する手法だったため、CI での scripts 実行を無効化。また、悪意あるバージョンが早期に検出・削除される猶予期間を確保するため、Renovate の更新を7日間遅延させる。

## Test plan
- [ ] CI が `--ignore-scripts` 付きで正常に pass することを確認
- [ ] Renovate Dashboard Issue で `minimumReleaseAge` 設定が反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)