### PR TITLE
Enable automerge for minor and patch version updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,12 @@
   "major": {
     "enabled": false
   },
+  "minor": {
+    "automerge": true
+  },
+  "patch": {
+    "automerge": true
+  },
   "packageRules": [
     {
       "groupName": "linters",


### PR DESCRIPTION
## 関連Issues
<!-- close #1-->

## 変更点
- renovate.json に `minor` と `patch` セクションを追加
- minor バージョン更新の自動マージを有効化
- patch バージョン更新の自動マージを有効化

## その他
- 既存の major バージョン更新は無効のままで、手動レビューが必要

https://claude.ai/code/session_01J6rTzUb1GV9chJBeaqXUGQ