### PR TITLE
fix(ci): release ワークフローを Node 20 に上げてリリース失敗を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - 'yarn.lock'
       - 'package.json'
       - 'tsconfig.json'
-      - '.github/workflows/on_pull_request.yml'
+      - '.github/workflows/ci.yml'
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
@@ -53,14 +53,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
@@ -73,14 +73,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
@@ -29,21 +29,21 @@ jobs:
     needs: prepare
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: '**/node_modules'
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
           yarn install --ignore-scripts
-      - uses: fregante/daily-version-action@v2
+      - uses: fregante/daily-version-action@v3
         id: daily-version
       - name: build
         run: yarn build
@@ -67,7 +67,7 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
       - name: Create release draft
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.daily-version.outputs.version }}
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
@@ -23,7 +23,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
   release:
     if: github.event.pull_request.merged == true
     needs: prepare
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
       - name: Cache node modules
         id: cache
@@ -42,7 +42,7 @@ jobs:
           key: cache-node-modules-${{ hashFiles('yarn.lock') }}
       - name: yarn install
         run: |
-          yarn install
+          yarn install --ignore-scripts
       - uses: fregante/daily-version-action@v2
         id: daily-version
       - name: build


### PR DESCRIPTION
## 背景

リリースの CI/CD が失敗し続けていました（[run 30276699948](https://github.com/tokku5552/github-language-extension/actions/runs/30276699948)）。

```
error serialize-javascript@7.0.7: The engine "node" is incompatible with this module.
Expected version ">=20.0.0". Got "18.20.8"
error Found incompatible module.
```

`ci.yml` は既に Node 20 に上がっていましたが、`release.yml` だけ Node 18 のまま取り残されていました。同一コミットで `ci` は成功（[run 30254917457](https://github.com/tokku5552/github-language-extension/actions/runs/30254917457)）、`release` だけ失敗していたのが根拠です。

その結果 #1004 は main にマージ済みなのにリリースが publish されていません。

## 変更内容

### 1. リリース失敗の修正 (1400350)

- `release.yml` の `node-version` を 18 → 20（両ジョブ）
- `yarn install` → `yarn install --ignore-scripts`
  - ea8f9e7 で `ci.yml` に入れたサプライチェーン対策が `release.yml` には適用されていなかったため揃えました。リリース経路だけ postinstall が実行される状態は対策の穴になっていました。

### 2. Actions の Node 24 対応 (4a3fc16)

Node 20 ランタイム廃止の警告が出ていたため、`ci.yml` / `release.yml` の actions を現行メジャーへ更新しました。

| action | before | after |
| --- | --- | --- |
| `actions/checkout` | v4 (node20) | v7 |
| `actions/setup-node` | v3 (node16) | v7 |
| `actions/cache` | v3 (node16) | v6 |
| `fregante/daily-version-action` | v2 (node20) | v3 |
| `softprops/action-gh-release` | v1 (node16) | v3 |

各メジャーの破壊的変更は確認済みで、今回の使い方には影響しません。

- `setup-node` v6 の「automatic caching を npm に限定」は暗黙の `package-manager-cache` 経路の話で、本リポジトリが使う明示的な `cache: yarn` は v7 でも引き続きサポートされています
- `daily-version-action` v3.0.0 / `action-gh-release` v2〜v3 / `cache` v5〜v6 はランタイム更新のみ
- `checkout` v7 の fork PR ブロックは `pull_request_target` / `workflow_run` 向けで、本リポジトリは `pull_request` を使用

### 3. ci.yml 自身の変更で CI が走るように修正 (663ec9c)

上記2コミットを push した時点で `ci` が起動しないことに気づきました。`ci.yml` の `paths` フィルタが `.github/workflows/on_pull_request.yml` という**存在しないファイル**（ci.yml へのリネーム前の名前）を参照したままだったためです。

このままだとワークフロー自身の変更が一切 CI で検証されず、今回の action 更新も未検証のままマージされることになるので、参照を `.github/workflows/ci.yml` に修正しました。これによりこの PR 上で lint / test / build が実際に走り、更新後の actions が動くことを確認できます。

## 今回あえて触れていないもの

いずれも失敗の原因ではなく、更新に追加作業やリスクを伴うため別対応にしました。

- **`labeler.yml` の `actions/labeler@v4`** — v5 で設定ファイルの書式が変わっており、現行の `.github/labeler.yml`（旧形式）の移行が必須。ラベリングが壊れるため見送り
- **`create_release_pr.yml` / `create_pr_main_to_develop.yml` の `checkout@v4`** — どちらも checkout が保存した認証情報で `git push` しており、v6 で認証情報の保存方式が変わっているため単純なバージョン上げにリスクあり

また `.github/labeler.yml` の `cicd` ルールが `github/workflows/**/*` になっており、先頭のドットが抜けてマッチしていないようです（既存の不具合）。

## 確認方法

このブランチが develop にマージされたあと、次の release PR (develop → main) のマージで `release` ワークフローが Node 20 で走ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
