### PR TITLE
ci: リリースワークフローを手動実行可能にする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,21 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build and archive only (skip the Chrome Web Store upload and the GitHub release)'
+        type: boolean
+        default: false
 jobs:
   prepare:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Manual runs always release main, whichever branch is picked in the UI
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || '' }}
       - uses: actions/setup-node@v7
         with:
           node-version: 20
@@ -25,11 +34,13 @@ jobs:
         run: |
           yarn install --ignore-scripts
   release:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || '' }}
       - uses: actions/setup-node@v7
         with:
           node-version: 20
@@ -58,7 +69,14 @@ jobs:
           rm -rf ./dist
           unzip extension.zip
           ls -lR ./dist
+      - name: Upload artifact (dry run)
+        if: github.event.inputs.dry_run == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: extension-${{ steps.daily-version.outputs.version }}
+          path: extension.zip
       - name: Submit
+        if: github.event.inputs.dry_run != 'true'
         run: |
           npx chrome-webstore-upload-cli@2 upload --source extension.zip --auto-publish
         env:
@@ -67,6 +85,7 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
       - name: Create release draft
+        if: github.event.inputs.dry_run != 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.daily-version.outputs.version }}


### PR DESCRIPTION
## 関連Issus
<!-- close #1-->
- なし

## 変更点
リリースワークフロー (`.github/workflows/release.yml`) に `workflow_dispatch` を追加し、リリース PR を main にマージしなくても手動でリリースできるようにしました。

- **`workflow_dispatch` トリガーを追加**
  `dry_run` (boolean, デフォルト `false`) を input として持ちます。
- **両 job の `if` 条件を拡張**
  `github.event_name == 'workflow_dispatch' ||` を追加。既存の `github.event.pull_request.merged == true` はそのまま残しているので、PR マージ時の自動リリースの挙動は変わりません。
- **手動実行時は `main` を固定で checkout**
  ```yaml
  ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || '' }}
  ```
  Actions UI でどのブランチを選んでも必ず `main` のコードをビルドします。デフォルトブランチが `develop` のため、これがないと誤って未リリースコードを公開してしまうリスクがあります。空文字は `actions/checkout` のデフォルト値なので、PR マージ時は従来どおりマージコミットを checkout します。
- **`dry_run` によるスキップ**
  `true` のとき Chrome Web Store へのアップロード (`Submit`) と GitHub Release 作成をスキップし、代わりに `extension.zip` を Actions の artifact としてアップロードします。公開せずにビルド結果を確認できます。

## その他
- **`workflow_dispatch` のボタンが Actions UI に表示されるのは、この PR がデフォルトブランチ (`develop`) にマージされた後です。**
- `dry_run` の判定に `inputs.dry_run` ではなく `github.event.inputs.dry_run`(文字列) を使っています。PR マージ時は `null` になり `!= 'true'` が成立するため、従来どおり公開まで実行されます。
- バージョン採番は `fregante/daily-version-action` のまま変更していません。そのため同じ日に手動実行すると日付ベースのタグが既存タグと衝突する可能性があります。必要になれば version を上書きできる input を後から追加できます。