### PR TITLE
feat: 設定画面を日本語化し、デバイスコードを GitHub へ飛ぶ前に見せる

### DIFF
--- a/src/api/deviceFlow.spec.ts
+++ b/src/api/deviceFlow.spec.ts
@@ -76,7 +76,7 @@ describe('requestDeviceCode', () => {
 
     await expect(requestDeviceCode('client-id')).rejects.toMatchObject({
       type: StatsErrorType.NETWORK,
-      message: expect.stringContaining('device flow enabled'),
+      message: expect.stringContaining('Device flow'),
     });
   });
 
@@ -97,7 +97,7 @@ describe('requestDeviceCode', () => {
     axiosMock.post.mockImplementationOnce(respondWith(502, '<html>') as never);
 
     await expect(requestDeviceCode('client-id')).rejects.toMatchObject({
-      message: expect.stringContaining('not answering'),
+      message: expect.stringContaining('応答していません'),
     });
   });
 
@@ -279,7 +279,7 @@ describe('pollForAccessToken', () => {
 
     await expect(promise).rejects.toMatchObject({
       type: StatsErrorType.NETWORK,
-      message: 'Sign-in cancelled.',
+      message: 'サインインをキャンセルしました。',
     });
     expect(axiosMock.post).not.toHaveBeenCalled();
   });
@@ -302,7 +302,7 @@ describe('pollForAccessToken', () => {
     answer({ status: 200, data: { access_token: 'gho_token' } });
 
     await expect(promise).rejects.toMatchObject({
-      message: 'Sign-in cancelled.',
+      message: 'サインインをキャンセルしました。',
     });
   });
 

--- a/src/api/deviceFlow.ts
+++ b/src/api/deviceFlow.ts
@@ -75,11 +75,15 @@ export const requestDeviceCode = async (
     status = response.status;
     body = response.data ?? {};
   } catch {
-    throw networkError('Could not reach GitHub to start sign-in.');
+    throw networkError(
+      'GitHub に接続できませんでした。ネットワークを確認してください。'
+    );
   }
 
   if (status >= 500) {
-    throw networkError('GitHub is not answering sign-in requests right now.');
+    throw networkError(
+      'GitHub がサインインのリクエストに応答していません。時間をおいて再試行してください。'
+    );
   }
 
   if (!body.device_code || !body.user_code || !body.verification_uri) {
@@ -90,7 +94,7 @@ export const requestDeviceCode = async (
     // that needs an app that has the flow turned off.
     throw networkError(
       body.error_description ??
-        'GitHub rejected the sign-in request. Check that the OAuth app exists and has the device flow enabled.'
+        'GitHub にサインインを拒否されました。OAuth App が存在し、Device flow が有効になっているか確認してください。'
     );
   }
 
@@ -103,7 +107,8 @@ export const requestDeviceCode = async (
   };
 };
 
-const cancelledError = (): StatsError => networkError('Sign-in cancelled.');
+const cancelledError = (): StatsError =>
+  networkError('サインインをキャンセルしました。');
 
 /** Sleeps, but gives up as soon as the caller aborts. */
 const wait = (seconds: number, signal?: AbortSignal): Promise<void> =>
@@ -147,7 +152,7 @@ export const pollForAccessToken = async (
     if (Date.now() >= deadline) {
       throw new StatsError(
         StatsErrorType.DEVICE_EXPIRED,
-        'The sign-in code expired. Start again.'
+        'コードの有効期限が切れました。もう一度サインインしてください。'
       );
     }
 
@@ -171,7 +176,9 @@ export const pollForAccessToken = async (
       if (signal?.aborted) {
         throw cancelledError();
       }
-      throw networkError('Could not reach GitHub while waiting for approval.');
+      throw networkError(
+        '承認を待っている間に GitHub へ接続できなくなりました。'
+      );
     }
 
     // A response that arrives in the same tick as the cancel must not be
@@ -181,7 +188,9 @@ export const pollForAccessToken = async (
     }
 
     if (status >= 500) {
-      throw networkError('GitHub is not answering sign-in requests right now.');
+      throw networkError(
+        'GitHub がサインインのリクエストに応答していません。時間をおいて再試行してください。'
+      );
     }
 
     if (body.access_token) {
@@ -198,16 +207,17 @@ export const pollForAccessToken = async (
       case 'expired_token':
         throw new StatsError(
           StatsErrorType.DEVICE_EXPIRED,
-          'The sign-in code expired. Start again.'
+          'コードの有効期限が切れました。もう一度サインインしてください。'
         );
       case 'access_denied':
         throw new StatsError(
           StatsErrorType.DEVICE_DENIED,
-          'Sign-in was declined on GitHub.'
+          'GitHub 側でサインインが拒否されました。'
         );
       default:
         throw networkError(
-          body.error_description ?? 'GitHub refused the sign-in request.'
+          body.error_description ??
+            'GitHub がサインインのリクエストを受け付けませんでした。'
         );
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@
 // `as string` keeps the type wide. Without it TypeScript infers the literal
 // type '' and every `=== ''` check below becomes a compile error the moment a
 // real client ID is filled in.
-export const GITHUB_OAUTH_CLIENT_ID = '' as string;
+export const GITHUB_OAUTH_CLIENT_ID = 'Ov23liwNGOaKwo4a1rpu' as string;
 
 /**
  * Scopes requested during sign-in.

--- a/src/options.spec.tsx
+++ b/src/options.spec.tsx
@@ -62,7 +62,13 @@ const renderOptions = () =>
     </ChakraProvider>
   );
 
-const tokenField = () => screen.getByLabelText(/personal access token/i);
+const tokenField = () => screen.getByLabelText(/パーソナルアクセストークン/);
+
+const writeText = jest.fn<Promise<void>, [string]>();
+
+const chromeTabsCreate = () =>
+  (global as unknown as { chrome: { tabs: { create: jest.Mock } } }).chrome.tabs
+    .create;
 
 describe('Options', () => {
   beforeEach(() => {
@@ -75,6 +81,13 @@ describe('Options', () => {
 
     const globalTyped = global as { chrome?: unknown };
     globalTyped.chrome = { tabs: { create: jest.fn() } };
+
+    writeText.mockReset();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
   });
 
   it('loads the saved token', async () => {
@@ -88,31 +101,87 @@ describe('Options', () => {
   });
 
   describe('sign in with GitHub', () => {
-    it('shows the code and opens the verification page', async () => {
+    it('shows the code without navigating away from it', async () => {
       // Never resolves: the code is only on screen while approval is pending.
       pollForAccessTokenMock.mockReturnValue(new Promise(() => undefined));
 
       renderOptions();
 
-      fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
 
       await waitFor(() => {
         expect(screen.getByTestId('device-code')).toBeInTheDocument();
       });
       expect(screen.getByText('ABCD-1234')).toBeInTheDocument();
-      expect(
-        (global as unknown as { chrome: { tabs: { create: jest.Mock } } })
-          .chrome.tabs.create
-      ).toHaveBeenCalledWith({ url: 'https://github.com/login/device' });
+      // Opening GitHub here would send the user to a form asking for a code
+      // they had not been shown yet.
+      expect(chromeTabsCreate()).not.toHaveBeenCalled();
+    });
+
+    it('copies the code before opening GitHub', async () => {
+      pollForAccessTokenMock.mockReturnValue(new Promise(() => undefined));
+
+      renderOptions();
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('device-code')).toBeInTheDocument();
+      });
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'コードをコピーして GitHub を開く',
+        })
+      );
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith('ABCD-1234');
+      });
+      expect(chromeTabsCreate()).toHaveBeenCalledWith({
+        url: 'https://github.com/login/device',
+      });
+    });
+
+    it('still opens GitHub when the clipboard is unavailable', async () => {
+      writeText.mockRejectedValue(new Error('denied'));
+      pollForAccessTokenMock.mockReturnValue(new Promise(() => undefined));
+
+      renderOptions();
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
+      await waitFor(() => {
+        expect(screen.getByTestId('device-code')).toBeInTheDocument();
+      });
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'コードをコピーして GitHub を開く',
+        })
+      );
+
+      await waitFor(() => {
+        expect(chromeTabsCreate()).toHaveBeenCalled();
+      });
+      // The code stays on screen so it can still be typed by hand.
+      expect(screen.getByText('ABCD-1234')).toBeInTheDocument();
     });
 
     it('stores the token once the user approves', async () => {
       renderOptions();
 
-      fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
 
       await waitFor(() => {
-        expect(screen.getByText('Connected as test_user.')).toBeInTheDocument();
+        expect(
+          screen.getByText('test_user として接続しました。')
+        ).toBeInTheDocument();
       });
       // The token that reaches storage is the one the poll produced, and it is
       // verified before being written - order included, not just both called.
@@ -133,7 +202,9 @@ describe('Options', () => {
 
       renderOptions();
 
-      fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
 
       await waitFor(() => {
         expect(
@@ -150,7 +221,9 @@ describe('Options', () => {
 
       renderOptions();
 
-      fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
 
       await waitFor(() => {
         expect(screen.getByText('No such app.')).toBeInTheDocument();
@@ -168,13 +241,17 @@ describe('Options', () => {
         .mockReturnValue(new Promise(() => undefined));
 
       renderOptions();
-      fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
       await waitFor(() => {
         expect(screen.getByTestId('device-code')).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
-      fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+      fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
       await waitFor(() => {
         expect(screen.getByTestId('device-code')).toBeInTheDocument();
       });
@@ -199,14 +276,16 @@ describe('Options', () => {
       );
 
       renderOptions();
-      fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'GitHub でサインイン' })
+      );
       await waitFor(() => {
         expect(screen.getByTestId('device-code')).toBeInTheDocument();
       });
 
-      fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+      fireEvent.click(screen.getByRole('button', { name: '削除' }));
       await waitFor(() => {
-        expect(screen.getByText(/Disconnected/)).toBeInTheDocument();
+        expect(screen.getByText(/接続を解除しました/)).toBeInTheDocument();
       });
 
       await act(async () => {
@@ -215,7 +294,7 @@ describe('Options', () => {
         );
       });
 
-      expect(screen.getByText(/Disconnected/)).toBeInTheDocument();
+      expect(screen.getByText(/接続を解除しました/)).toBeInTheDocument();
     });
 
     it('is hidden when no OAuth app is configured', async () => {
@@ -227,7 +306,7 @@ describe('Options', () => {
         expect(tokenField()).toBeInTheDocument();
       });
       expect(
-        screen.queryByRole('button', { name: /sign in/i })
+        screen.queryByRole('button', { name: 'GitHub でサインイン' })
       ).not.toBeInTheDocument();
     });
   });
@@ -237,10 +316,12 @@ describe('Options', () => {
       renderOptions();
 
       fireEvent.change(tokenField(), { target: { value: 'ghp_new' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      fireEvent.click(screen.getByRole('button', { name: '保存' }));
 
       await waitFor(() => {
-        expect(screen.getByText('Connected as test_user.')).toBeInTheDocument();
+        expect(
+          screen.getByText('test_user として接続しました。')
+        ).toBeInTheDocument();
       });
       expect(validateTokenMock).toHaveBeenCalledWith('ghp_new');
       expect(setToken).toHaveBeenCalledWith('ghp_new');
@@ -254,10 +335,12 @@ describe('Options', () => {
       renderOptions();
 
       fireEvent.change(tokenField(), { target: { value: 'bad' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      fireEvent.click(screen.getByRole('button', { name: '保存' }));
 
       await waitFor(() => {
-        expect(screen.getByText('Token was rejected.')).toBeInTheDocument();
+        expect(
+          screen.getByText(/GitHub にトークンを拒否されました/)
+        ).toBeInTheDocument();
       });
       expect(setToken).not.toHaveBeenCalled();
     });
@@ -265,10 +348,12 @@ describe('Options', () => {
     it('refuses to verify an empty token', async () => {
       renderOptions();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      fireEvent.click(screen.getByRole('button', { name: '保存' }));
 
       await waitFor(() => {
-        expect(screen.getByText('Enter a token first.')).toBeInTheDocument();
+        expect(
+          screen.getByText('トークンを入力してください。')
+        ).toBeInTheDocument();
       });
       expect(validateTokenMock).not.toHaveBeenCalled();
     });
@@ -282,10 +367,10 @@ describe('Options', () => {
     await waitFor(() => {
       expect(tokenField()).toHaveValue('ghp_saved');
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Disconnected/)).toBeInTheDocument();
+      expect(screen.getByText(/接続を解除しました/)).toBeInTheDocument();
     });
     expect(clearToken).toHaveBeenCalled();
     expect(tokenField()).toHaveValue('');

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/api';
 import { GITHUB_OAUTH_CLIENT_ID } from '@/config';
 import { clearToken, getToken, setToken } from '@/storage';
+import { StatsErrorType } from '@/types/enums';
 import { StatsError } from '@/types/stats';
 import {
   Box,
@@ -42,12 +43,34 @@ const openVerificationPage = (url: string): void => {
   window.open(url, '_blank', 'noopener');
 };
 
-const describe = (caught: unknown, fallback: string): string =>
-  caught instanceof StatsError ? caught.message : fallback;
+/**
+ * Translates a failure for this page.
+ *
+ * Mapped by type rather than by reusing `error.message`, because the messages
+ * on errors from src/api/github.ts are shared with the popup, which is in
+ * English. Device flow errors are options-page-only and already carry Japanese
+ * text, so those pass through.
+ */
+const messageFor = (caught: unknown, fallback: string): string => {
+  if (!(caught instanceof StatsError)) {
+    return fallback;
+  }
+  switch (caught.type) {
+    case StatsErrorType.UNAUTHORIZED:
+      return 'GitHub にトークンを拒否されました。値が正しいか確認してください。';
+    case StatsErrorType.RATE_LIMITED:
+      return 'GitHub API のレート制限に達しました。しばらく待ってから再試行してください。';
+    case StatsErrorType.NOT_FOUND:
+      return 'GitHub がこのリクエストを受け付けませんでした。';
+    default:
+      return caught.message || fallback;
+  }
+};
 
 export const Options = () => {
   const [token, setTokenValue] = useState('');
   const [status, setStatus] = useState<Status>({ kind: 'idle' });
+  const [copied, setCopied] = useState(false);
   const abort = useRef<AbortController>();
   const helperColor = useColorModeValue('gray.600', 'gray.400');
   // A build without a configured OAuth app (the constant left at '') falls
@@ -98,6 +121,7 @@ export const Options = () => {
 
   const onSignIn = async () => {
     const { controller, isCurrent } = beginAttempt();
+    setCopied(false);
     setStatus({ kind: 'verifying' });
 
     try {
@@ -105,8 +129,10 @@ export const Options = () => {
       if (!isCurrent()) {
         return;
       }
+      // The verification page is deliberately NOT opened here. It asks for a
+      // code that is only shown on this page, so sending the user there before
+      // they have seen it leaves them staring at an empty field.
       setStatus({ kind: 'awaiting', code });
-      openVerificationPage(code.verificationUri);
 
       const accessToken = await pollForAccessToken(
         GITHUB_OAUTH_CLIENT_ID,
@@ -127,13 +153,29 @@ export const Options = () => {
       }
       setStatus({
         kind: 'error',
-        message: describe(caught, 'Sign-in failed.'),
+        message: messageFor(caught, 'サインインに失敗しました。'),
       });
     }
   };
 
+  /**
+   * Puts the code on the clipboard before opening GitHub, so the field waiting
+   * on the other side can just be pasted into. Opening still happens if the
+   * clipboard is unavailable; the code stays on screen either way.
+   */
+  const onCopyAndOpen = async (code: DeviceCode) => {
+    try {
+      await navigator.clipboard.writeText(code.userCode);
+      setCopied(true);
+    } catch {
+      setCopied(false);
+    }
+    openVerificationPage(code.verificationUri);
+  };
+
   const onCancelSignIn = () => {
     endAttempt();
+    setCopied(false);
     setStatus({ kind: 'idle' });
   };
 
@@ -143,7 +185,7 @@ export const Options = () => {
       // Pressing Save with the field empty also ends a pending sign-in - not
       // just an empty save. Typing in the field alone does nothing.
       endAttempt();
-      setStatus({ kind: 'error', message: 'Enter a token first.' });
+      setStatus({ kind: 'error', message: 'トークンを入力してください。' });
       return;
     }
     const { isCurrent } = beginAttempt();
@@ -160,7 +202,7 @@ export const Options = () => {
       }
       setStatus({
         kind: 'error',
-        message: describe(caught, 'Could not verify the token.'),
+        message: messageFor(caught, 'トークンを検証できませんでした。'),
       });
     }
   };
@@ -178,10 +220,8 @@ export const Options = () => {
         GitHub Language Stats
       </Heading>
       <Text fontSize="sm" color={helperColor} mb={5}>
-        Without credentials the extension uses the anonymous GitHub REST API,
-        which is limited to 60 requests per hour and cannot report commits, PRs,
-        issues or rank. Connecting an account raises the limit to 5,000 requests
-        per hour and restores the full card.
+        アカウントを接続していない間は、匿名の GitHub REST API
+        を使います。1時間あたり60リクエストまでに制限され、コミット数・PR数・Issue数・ランクは取得できません。接続すると1時間あたり5,000リクエストになり、これらがすべて表示されます。
       </Text>
 
       {signInAvailable && (
@@ -193,11 +233,11 @@ export const Options = () => {
             isLoading={status.kind === 'verifying'}
             isDisabled={status.kind === 'awaiting'}
           >
-            Sign in with GitHub
+            GitHub でサインイン
           </Button>
           <Text fontSize="xs" color={helperColor} mt={2}>
-            No scopes are requested, so GitHub only confirms who you are.
-            Nothing in your account can be read beyond what is already public.
+            権限（スコープ）は一切要求しません。GitHub
+            が確認するのはあなたが誰かということだけで、公開されている以上の情報は読み取られません。
           </Text>
 
           {status.kind === 'awaiting' && (
@@ -208,28 +248,57 @@ export const Options = () => {
               borderRadius="md"
               data-testid="device-code"
             >
-              <Text fontSize="sm" mb={2}>
-                Enter this code on GitHub to finish signing in:
+              <Text fontSize="sm" fontWeight="bold" mb={1}>
+                ステップ1: このコードをコピーします
               </Text>
-              <Code fontSize="xl" px={3} py={1} letterSpacing="widest">
+              <Code
+                fontSize="2xl"
+                px={3}
+                py={2}
+                letterSpacing="widest"
+                display="block"
+                textAlign="center"
+                my={2}
+              >
                 {status.code.userCode}
               </Code>
-              <Text fontSize="sm" mt={3}>
+
+              <Text fontSize="sm" fontWeight="bold" mt={4} mb={2}>
+                ステップ2: GitHub で貼り付けて承認します
+              </Text>
+              <Button
+                size="sm"
+                bg="#4299E1"
+                color="white"
+                onClick={() => onCopyAndOpen(status.code)}
+              >
+                コードをコピーして GitHub を開く
+              </Button>
+              {copied && (
+                <Text fontSize="xs" color="green.500" mt={2}>
+                  コピーしました。開いたタブで貼り付けてください。
+                </Text>
+              )}
+              <Text fontSize="xs" color={helperColor} mt={2}>
+                開かない場合は{' '}
                 <Link
                   color="#4299E1"
                   onClick={() =>
                     openVerificationPage(status.code.verificationUri)
                   }
                 >
-                  Reopen {status.code.verificationUri}
-                </Link>
+                  {status.code.verificationUri}
+                </Link>{' '}
+                を開いて、上のコードを手で入力してください。
               </Text>
-              <HStack mt={3}>
+
+              <HStack mt={4}>
                 <Button size="sm" variant="outline" onClick={onCancelSignIn}>
-                  Cancel
+                  キャンセル
                 </Button>
                 <Text fontSize="sm" color={helperColor}>
-                  Waiting for approval...
+                  承認を待っています...
+                  承認するとこの画面が自動で切り替わります。
                 </Text>
               </HStack>
             </Box>
@@ -242,8 +311,8 @@ export const Options = () => {
       <FormControl>
         <FormLabel fontSize="sm">
           {signInAvailable
-            ? 'Or paste a personal access token'
-            : 'GitHub personal access token'}
+            ? 'または、パーソナルアクセストークンを貼り付ける'
+            : 'GitHub パーソナルアクセストークン'}
         </FormLabel>
         <Input
           type="password"
@@ -252,9 +321,11 @@ export const Options = () => {
           onChange={(event) => setTokenValue(event.target.value)}
         />
         <FormHelperText color={helperColor}>
-          A classic token needs no scopes for public data; add <code>repo</code>{' '}
-          to include your private contributions. The token is stored locally in
-          this browser profile and is only ever sent to api.github.com.
+          公開データだけならスコープなしの classic
+          トークンで足ります。自分のプライベートリポジトリの統計も含めたい場合は{' '}
+          <code>repo</code>{' '}
+          を付けてください。トークンはこのブラウザのプロフィール内にのみ保存され、送信先は
+          api.github.com だけです。
         </FormHelperText>
       </FormControl>
 
@@ -266,21 +337,21 @@ export const Options = () => {
           onClick={onSave}
           isLoading={status.kind === 'verifying'}
         >
-          Save
+          保存
         </Button>
         <Button variant="outline" onClick={onClear}>
-          Clear
+          削除
         </Button>
       </HStack>
 
       {status.kind === 'saved' && (
         <Text mt={3} fontSize="sm" color="green.500">
-          Connected as {status.login}.
+          {status.login} として接続しました。
         </Text>
       )}
       {status.kind === 'cleared' && (
         <Text mt={3} fontSize="sm" color={helperColor}>
-          Disconnected. The extension will fall back to anonymous requests.
+          接続を解除しました。以降は匿名のリクエストに戻ります。
         </Text>
       )}
       {status.kind === 'error' && (

--- a/src/popup.spec.tsx
+++ b/src/popup.spec.tsx
@@ -25,6 +25,16 @@ const stats: Stats = {
   source: StatsSource.REST,
 };
 
+/** Mutable so a test can pin either prompt label, independent of config.ts. */
+let clientId = '';
+
+jest.mock('@/config', () => ({
+  get GITHUB_OAUTH_CLIENT_ID() {
+    return clientId;
+  },
+  GITHUB_OAUTH_SCOPE: '',
+}));
+
 jest.mock('@/api', () => ({
   fetchStats: jest.fn(),
   getGitHubUsername: jest.fn().mockReturnValue('testuser'),
@@ -55,6 +65,7 @@ const renderPopup = () =>
 describe('Popup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clientId = '';
     (getGitHubUsername as jest.Mock).mockReturnValue('testuser');
     getTokenMock.mockResolvedValue('');
     getCachedStatsMock.mockResolvedValue(undefined);
@@ -198,6 +209,19 @@ describe('Popup', () => {
       ).toBeInTheDocument();
     });
     expect(fetchStatsMock).not.toHaveBeenCalled();
+  });
+
+  it('offers sign-in rather than a token once an OAuth app is configured', async () => {
+    clientId = 'client-id';
+
+    renderPopup();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign in with GitHub')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText('Add a personal access token')
+    ).not.toBeInTheDocument();
   });
 
   it('hides the token prompt once a token is saved', async () => {


### PR DESCRIPTION
#1040 の続きです。マージ後に実際に拡張機能を読み込んで試したところ出てきた2点を直し、あわせて OAuth App の client ID を設定しました。

## 1. デバイスコードの導線が破綻していた

`requestDeviceCode` が返った瞬間に GitHub の認証タブを自動で開いていました。ユーザーはコード入力欄の前に立たされますが、**肝心のコードは今引き剥がされたばかりのタブにある**ので、何を入力すればいいのか分かりません。GitHub 側の画面にもヒントはありません。

自動遷移をやめて2ステップに分けました。

- **ステップ1**: コードを大きく表示する。ここで画面は動かない
- **ステップ2**: 「コードをコピーして GitHub を開く」ボタン。クリップボードに入れてから遷移するので、向こうでは貼るだけ

クリップボードが拒否された場合でもタブは開き、コードは画面に残るので手入力できます。タブが開かない場合に備えて URL のリンクも併記しています。

GitHub のデバイスフローは `verification_uri_complete`（コード埋め込み済み URL）を返さないため、コピペを楽にする方向が現実解です。

## 2. 設定画面を日本語化

Chrome Web Store のリスティングが全て日本語なので、この画面を読むのは日本語話者です。

範囲は**設定画面のみ**で、ポップアップは英語のままにしています。そのため、両方が共有する `src/api/github.ts` のエラー（トークン拒否・レート制限など）は、発生源ではなく**この画面の境界でエラー種別ごとに翻訳**しています。デバイスフローのメッセージはこの画面にしか出ないので、そちらは直接日本語にしました。

## 3. client ID の設定

OAuth App を登録して Device flow を有効化し、client ID を `src/config.ts` に入れました。これでサインインボタンが表示されるようになります。client ID は公開前提の値（拡張機能に同梱され、デバイスフローは client secret を使わない）なので、シークレットではなくリポジトリに置いています。

## テストの脆さを1つ修正

client ID を設定した途端、**無関係に見えるポップアップのテストが2件落ちました**。ポップアップの案内文は client ID の有無で切り替わるのに、テストが実際の `src/config.ts` の値（＝未設定）を読んでいたためです。コードではなくテストの問題なので、config をモックして検証したい分岐を明示する形に直し、これまで一度も通っていなかった「設定済み」側の分岐にもテストを足しました。

## Test plan

- [x] `npx jest` — 98 passed / 13 suites（最新の develop に rebase 後、`yarn install` し直して再実行）
- [x] `npx tsc --noEmit` / `npx eslint src` / `npx prettier -c .` — クリーン
- [x] `yarn build` — 成功
- [x] 設定画面を実際にレンダリングして日本語表示を目視確認
- [x] クリップボード成功時・拒否時の両経路をテストで検証
- [ ] **Device flow の実際の承認フロー（コード入力 → 承認 → 統計表示）は未検証。** #1040 から持ち越しの項目です

🤖 Generated with [Claude Code](https://claude.com/claude-code)